### PR TITLE
Fix min non-zero value aggregation with values between 0 and 1

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -84,6 +84,44 @@ describe("getSnapshot", () => {
     expect(snapshot2).toBe(snapshot);
     expect(snapshot2.getTotalCount()).toBe(4);
   });
+
+  it("should ignore zero from the minimum non-zero value", () => {
+    rolling = new RollingWindow();
+
+    rolling.recordValue(0);
+    rolling.recordValue(1);
+    jest.runOnlyPendingTimers();
+    rolling.recordValue(0);
+    rolling.recordValue(10);
+
+    const snapshot = rolling.getSnapshot();
+    expect(snapshot.minNonZeroValue).toBe(1);
+  });
+
+  it("should not ignore the minimum non-zero value from a chunk that has a value between 0 and 1", () => {
+    rolling = new RollingWindow();
+
+    rolling.recordValue(0.5);
+    rolling.recordValue(1);
+    jest.runOnlyPendingTimers();
+    rolling.recordValue(10);
+
+    const snapshot = rolling.getSnapshot();
+    expect(snapshot.minNonZeroValue).toBe(1);
+  });
+
+  it("should aggregate minimum non-zero values even if all chunks have a value between 0 and 1", () => {
+    rolling = new RollingWindow();
+
+    rolling.recordValue(0.5);
+    rolling.recordValue(1);
+    jest.runOnlyPendingTimers();
+    rolling.recordValue(0.5);
+    rolling.recordValue(1);
+
+    const snapshot = rolling.getSnapshot();
+    expect(snapshot.minNonZeroValue).toBe(1);
+  });
 });
 
 describe("ES module interop", () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -122,6 +122,14 @@ describe("getSnapshot", () => {
     const snapshot = rolling.getSnapshot();
     expect(snapshot.minNonZeroValue).toBe(1);
   });
+
+  it("should throw the error from hdr-histogram-js if a negative value is given", () => {
+    rolling = new RollingWindow();
+
+    expect(() => {
+      rolling.recordValue(-2);
+    }).toThrow(new Error("Histogram recorded value cannot be negative."));
+  });
 });
 
 describe("ES module interop", () => {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class RollingWindow {
   }
 
   recordValue(value) {
-    this.chunks[this.pos].recordValue(value);
+    this.chunks[this.pos].recordValue(Math.floor(value));
   }
 
   getSnapshot(givenSnapshot) {

--- a/index.js
+++ b/index.js
@@ -9,13 +9,19 @@ class RollingWindow {
   } = {}) {
     assert(numChunks > 0, "numChunks must be more than 0");
     assert(timeWindow > 0, "timeWindow must be more than 0");
-    assert.equal(typeof buildHistogram, "function", "buildHistogram must be a function");
+    assert.equal(
+      typeof buildHistogram,
+      "function",
+      "buildHistogram must be a function"
+    );
 
     this.buildHistogram = buildHistogram;
     this.timeWindow = timeWindow;
     this.numChunks = numChunks;
 
-    this.chunks = Array(numChunks + 1).fill().map(() => buildHistogram());
+    this.chunks = Array(numChunks + 1)
+      .fill()
+      .map(() => buildHistogram());
     this.pos = 0;
     this.rotate = this.rotate.bind(this);
 
@@ -28,6 +34,8 @@ class RollingWindow {
   }
 
   recordValue(value) {
+    // `Math.floor()` for fixing an issue of min non-zero value aggregation.
+    // https://github.com/shuhei/rolling-window/pull/6
     this.chunks[this.pos].recordValue(Math.floor(value));
   }
 
@@ -54,7 +62,7 @@ class RollingWindow {
   start() {
     if (!this.timer) {
       this.timer = setInterval(this.rotate, this.timeWindow / this.numChunks);
-      if (typeof this.timer.unref === 'function') {
+      if (typeof this.timer.unref === "function") {
         this.timer.unref();
       }
     }


### PR DESCRIPTION
@DeTeam reported that `snapshot.minNonZeroValue` becomes `Number.MAX_SAFE_INTEGER` even if it has some entries.

The last two of the added test cases are failing.