### PR TITLE
Update node versions in workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updated the Node.js versions used in Github workflows to those that are currently supported (maintenance, LTS, current).